### PR TITLE
Fix for compatibility with rabix

### DIFF
--- a/delly_call.cwl
+++ b/delly_call.cwl
@@ -18,6 +18,12 @@ inputs:
     inputBinding:
       prefix: --svtype
 
+  tumor_sample_name:
+    type: string
+
+  normal_sample_name:
+    type: string
+
   genome:
     type: File
     inputBinding:


### PR DESCRIPTION
Added tumor_sample_name and normal_sample_name to delly_call.cwl

Roslin will either need similar changes to work with `rabix` or another solution that accomplishes the same thing and is less hack-y